### PR TITLE
Add integration tests for version commands

### DIFF
--- a/tests/Integration.Tests.ps1
+++ b/tests/Integration.Tests.ps1
@@ -1,20 +1,20 @@
 BeforeAll {
     # Set up a temporary git repository before tests
-    Set-Location -Path "TestDrive:"
+    Set-Location -Path $TestDrive
     git init
 }
 
 Describe "Integration Tests for Get- and Set-VVVersion" {
     BeforeAll {
         # Create a new file in the temporary repository
-        $FilePath = Join-Path -Path "TestDrive:" -ChildPath "testfile.txt"
+        $FilePath = Join-Path -Path $TestDrive -ChildPath "testfile.txt"
         Set-Content -Path $FilePath -Value "Test content"
         git add .
         git commit -m "Initial commit with test file"
     }
 
     It "Creates versions using Set-VVVersion" {
-        $Metadata = @{
+        $MetadataHash = @{
             "Author" = "Emanuel Palm"
             "Description" = "Testing the commands"
             "Feature" = "N/A"
@@ -25,21 +25,23 @@ Describe "Integration Tests for Get- and Set-VVVersion" {
             "Category" = "IntegrationTest"
             "Priority" = "High"
             "ReleaseDate" = "2024-05-21"
-            "ExtraCharacters" = '!"#€%&/()=?`_:;*^©@£$∞§|[]≈±´\{}¡”¥≠}¢¿@•Ωé®†µüıœπ˙æøﬁªß∂ƒ√ª˛ƒ∂ﬁßåäöÅÄÖ'
+            "ExtraCharacters" = '!"#€%&/()=?`_:;*^©@£$∞§|[]≈±´\{}¡¥≠}¢¿@•Ωé®†µüıœπ˙æøﬁªß∂ƒ√ª˛ƒ∂ﬁßåäöÅÄÖ'
         }
-        { Set-VVVersion -Path $FilePath -Version "1.0.0" -Metadata $Metadata } | Should -Not -Throw
-        { Set-VVVersion -Path $FilePath -Version "1.2.3" -Metadata $Metadata } | Should -Not -Throw
-        { Set-VVVersion -Path $FilePath -Version "1.1.1" -Metadata $Metadata } | Should -Not -Throw
+        { Set-VVVersion -Path $FilePath -Version "1.0.0" -Metadata $MetadataHash -WarningAction SilentlyContinue } | Should -Not -Throw
+        { Set-VVVersion -Path $FilePath -Version "1.2.3" -Metadata $MetadataHash -WarningAction SilentlyContinue } | Should -Not -Throw
+        { Set-VVVersion -Path $FilePath -Version "1.10.1" -Metadata $MetadataHash -WarningAction SilentlyContinue } | Should -Not -Throw
+        { Set-VVVersion -Path $FilePath -Version "1.1.1" -Metadata $MetadataHash -WarningAction SilentlyContinue } | Should -Not -Throw
     }
 
     It "Retrieves versions using Get-VVVersion" {
         $Versions = Get-VVVersion -Path $FilePath
-        $Versions.Count | Should -Be 2
+        $Versions.Count | Should -Be 4
         # Versions should be in descending version order, regardless of creation order
-        $Versions[0].Version.ToString() | Should -Be "1.2.3"
-        $Versions[1].Version.ToString() | Should -Be "1.1.1"
-        $Versions[2].Version.ToString() | Should -Be "1.0.0"
-        $Versions[0].Data.ExtraCharacters | Should -Be '!"#€%&/()=?`_:;*^©@£$∞§|[]≈±´\{}¡”¥≠}¢¿@•Ωé®†µüıœπ˙æøﬁªß∂ƒ√ª˛ƒ∂ﬁßåäöÅÄÖ'
+        $Versions[0].Version.ToString() | Should -Be "1.10.1"
+        $Versions[1].Version.ToString() | Should -Be "1.2.3"
+        $Versions[2].Version.ToString() | Should -Be "1.1.1"
+        $Versions[3].Version.ToString() | Should -Be "1.0.0"
+        $Versions[0].Data.ExtraCharacters | Should -Be '!"#€%&/()=?`_:;*^©@£$∞§|[]≈±´\{}¡¥≠}¢¿@•Ωé®†µüıœπ˙æøﬁªß∂ƒ√ª˛ƒ∂ﬁßåäöÅÄÖ'
         $Versions[0].Data.Commit | Should -Be (git rev-parse --verify HEAD)
     }
 }

--- a/tests/Integration.Tests.ps1
+++ b/tests/Integration.Tests.ps1
@@ -1,0 +1,45 @@
+BeforeAll {
+    # Set up a temporary git repository before tests
+    Set-Location -Path "TestDrive:"
+    git init
+}
+
+Describe "Integration Tests for Get- and Set-VVVersion" {
+    BeforeAll {
+        # Create a new file in the temporary repository
+        $FilePath = Join-Path -Path "TestDrive:" -ChildPath "testfile.txt"
+        Set-Content -Path $FilePath -Value "Test content"
+        git add .
+        git commit -m "Initial commit with test file"
+    }
+
+    It "Creates versions using Set-VVVersion" {
+        $Metadata = @{
+            "Author" = "Emanuel Palm"
+            "Description" = "Testing the commands"
+            "Feature" = "N/A"
+            "ReviewedBy" = "None"
+            "ApprovedBy" = "Approver1"
+            "Tested" = $true
+            "Passed" = $true
+            "Category" = "IntegrationTest"
+            "Priority" = "High"
+            "ReleaseDate" = "2024-05-21"
+            "ExtraCharacters" = '!"#€%&/()=?`_:;*^©@£$∞§|[]≈±´\{}¡”¥≠}¢¿@•Ωé®†µüıœπ˙æøﬁªß∂ƒ√ª˛ƒ∂ﬁßåäöÅÄÖ'
+        }
+        { Set-VVVersion -Path $FilePath -Version "1.0.0" -Metadata $Metadata } | Should -Not -Throw
+        { Set-VVVersion -Path $FilePath -Version "1.2.3" -Metadata $Metadata } | Should -Not -Throw
+        { Set-VVVersion -Path $FilePath -Version "1.1.1" -Metadata $Metadata } | Should -Not -Throw
+    }
+
+    It "Retrieves versions using Get-VVVersion" {
+        $Versions = Get-VVVersion -Path $FilePath
+        $Versions.Count | Should -Be 2
+        # Versions should be in descending version order, regardless of creation order
+        $Versions[0].Version.ToString() | Should -Be "1.2.3"
+        $Versions[1].Version.ToString() | Should -Be "1.1.1"
+        $Versions[2].Version.ToString() | Should -Be "1.0.0"
+        $Versions[0].Data.ExtraCharacters | Should -Be '!"#€%&/()=?`_:;*^©@£$∞§|[]≈±´\{}¡”¥≠}¢¿@•Ωé®†µüıœπ˙æøﬁªß∂ƒ√ª˛ƒ∂ﬁßåäöÅÄÖ'
+        $Versions[0].Data.Commit | Should -Be (git rev-parse --verify HEAD)
+    }
+}

--- a/tests/Integration.Tests.ps1
+++ b/tests/Integration.Tests.ps1
@@ -1,11 +1,8 @@
-BeforeAll {
-    # Set up a temporary git repository before tests
-    Set-Location -Path $TestDrive
-    git init
-}
-
 Describe "Integration Tests for Get- and Set-VVVersion" {
     BeforeAll {
+        # Set up a temporary git repository before tests
+        Set-Location -Path $TestDrive
+        git init
         # Create a new file in the temporary repository
         $FilePath = Join-Path -Path $TestDrive -ChildPath "testfile.txt"
         Set-Content -Path $FilePath -Value "Test content"

--- a/tests/Integration.Tests.ps1
+++ b/tests/Integration.Tests.ps1
@@ -3,6 +3,10 @@ Describe "Integration Tests for Get- and Set-VVVersion" {
         # Set up a temporary git repository before tests
         Set-Location -Path $TestDrive
         git init
+
+        git config user.name "VeilVer"
+        git config user.email "veilver@pipe.how"
+
         # Create a new file in the temporary repository
         $FilePath = Join-Path -Path $TestDrive -ChildPath "testfile.txt"
         Set-Content -Path $FilePath -Value "Test content"


### PR DESCRIPTION
Implements integration tests for Get- and Set-VVVersion commands in a new `tests/Integration.Tests.ps1` file, working against a temporary Pester drive path.

- **Creates a new integration test file**: Adds `tests/Integration.Tests.ps1` to house integration tests for both `Get-VVVersion` and `Set-VVVersion` commands.
- **Sets up a temporary git repository**: Utilizes Pester's `TestDrive:` to create a temporary git repository in a `BeforeAll` block, ensuring a clean environment for each test run.
- **Tests version creation and retrieval**: Includes tests for creating versions with `Set-VVVersion` using a detailed metadata hashtable and retrieving those versions with `Get-VVVersion`, verifying correct version ordering and metadata integrity.
- **Deletes old test files**: Removes `tests/Get-VVVersion.Tests.ps1` and `tests/Set-VVVersion.Tests.ps1`, consolidating tests into the new integration test file.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PalmEmanuel/VeilVer?shareId=88c7a48e-5682-41ee-9020-f114d1e3c973).