### PR TITLE
Add -Checkout parameter to Get-VVVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,33 +16,11 @@ Install-Module -Name VeilVer
 
 ## Commands
 
-### Set-VVVersion
+The module provides the following commands:
 
-Sets or updates a git tag for a document with specified metadata.
-
-```powershell
-Set-VVVersion -Path <path/to/document> -Version <semantic-version> -Metadata <metadata-hashtable>
-```
-
-### Get-VVVersion
-
-Retrieves git tags and their associated messages for a document.
-
-```powershell
-Get-VVVersion -Path <path/to/document>
-```
-
-### Remove-VVVersion
-
-Removes a specific version from a file.
-
-```powershell
-Remove-VVVersion -Path <path/to/document> -Version <semantic-version>
-```
-
-```powershell
-Remove-VVVersion -Tag <full-git-tag>
-```
+- `Get-VVVersion` to get the hidden version of a document.
+- `Set-VVVersion` to set the hidden version of a document.
+- `Remove-VVVersion` to remove a hidden version from a file.
 
 <!-- References -->
 [VeilVerDownloads]: https://img.shields.io/powershellgallery/dt/VeilVer

--- a/docs/help/Get-VVVersion.md
+++ b/docs/help/Get-VVVersion.md
@@ -63,7 +63,8 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-{{ Fill Force Description }}
+
+Overwrite the file if there are pending changes.
 
 ```yaml
 Type: SwitchParameter

--- a/docs/help/Get-VVVersion.md
+++ b/docs/help/Get-VVVersion.md
@@ -9,40 +9,85 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Gets the hidden version of a document.
+Gets the hidden version of a document or checks out a version as a file using git blob tags.
 
 ## SYNTAX
 
+### Default (Default)
 ```
 Get-VVVersion [-Path] <String> [<CommonParameters>]
 ```
 
+### Checkout
+```
+Get-VVVersion [-Path] <String> [-Checkout] [-Version] <Version> [<CommonParameters>]
+```
+
 ## DESCRIPTION
 
-Gets the hidden version of a document, based on git tags on the blob.
+Gets the hidden version of a document, based on git tags on the blob. If the `-Checkout` parameter is specified, it checks out the version as a file using git blob tags.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> Get-VVVersion -DocumentPath "C:\path\to\document.md"
+PS C:\> Get-VVVersion -Path "C:\path\to\document.md"
 ```
 
 Gets the hidden version of the document at "C:\path\to\document.md".
+
+### Example 2
+```powershell
+PS C:\> Get-VVVersion -Path "C:\path\to\document.md" -Checkout -Version 1.2.3
+```
+
+Checks out version 1.2.3 of the document at "C:\path\to\document.md" as a file using git blob tags.
 
 ## PARAMETERS
 
 ### -Path
 
-The path to the document to get the hidden versions of.
+The path to the document to get the hidden versions of or to checkout a version from.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: Default, Checkout
 Aliases:
 
 Required: True
 Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Checkout
+
+Indicates that the command should checkout the version as a file using git blob tags.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Checkout
+Aliases:
+
+Required: True
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Version
+
+Specifies the version to checkout as a file. This parameter is required when using the `-Checkout` parameter.
+
+```yaml
+Type: Version
+Parameter Sets: Checkout
+Aliases:
+
+Required: True
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/help/Get-VVVersion.md
+++ b/docs/help/Get-VVVersion.md
@@ -13,14 +13,15 @@ Gets the hidden version of a document or checks out a version as a file using gi
 
 ## SYNTAX
 
-### Default (Default)
+### Path (Default)
 ```
-Get-VVVersion [-Path] <String> [<CommonParameters>]
+Get-VVVersion -Path <String> [-Version <Version>] [<CommonParameters>]
 ```
 
 ### Checkout
 ```
-Get-VVVersion [-Path] <String> [-Checkout] [-Version] <Version> [<CommonParameters>]
+Get-VVVersion -Path <String> -Version <Version> [-Checkout] [-Force]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -45,22 +46,6 @@ Checks out version 1.2.3 of the document at "C:\path\to\document.md" as a file u
 
 ## PARAMETERS
 
-### -Path
-
-The path to the document to get the hidden versions of or to checkout a version from.
-
-```yaml
-Type: String
-Parameter Sets: Default, Checkout
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Checkout
 
 Indicates that the command should checkout the version as a file using git blob tags.
@@ -77,9 +62,52 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Force
+{{ Fill Force Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Checkout
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+
+The path to the document to get the hidden versions of or to checkout a version from.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Version
 
 Specifies the version to checkout as a file. This parameter is required when using the `-Checkout` parameter.
+
+```yaml
+Type: Version
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ```yaml
 Type: Version

--- a/source/Private/Get-GitBlobHash.ps1
+++ b/source/Private/Get-GitBlobHash.ps1
@@ -1,0 +1,12 @@
+function Get-GitBlobHash {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateScript({ Test-Path $_ -PathType Leaf }, ErrorMessage = 'Path must exist and be a file.')]
+        [string]$Path
+    )
+
+    $BlobHash = Invoke-GitCommand 'hash-object', '-t', 'blob', $Path
+
+    Write-Output $BlobHash
+}

--- a/source/Private/Get-GitBlobTag.ps1
+++ b/source/Private/Get-GitBlobTag.ps1
@@ -1,4 +1,4 @@
-function Get-GitBlobTags {
+function Get-GitBlobTag {
     [CmdletBinding()]
     param (
         # Does not need to exist anymore, but must be a valid path
@@ -8,7 +8,8 @@ function Get-GitBlobTags {
     )
 
     # Example tag: VV/demo/docs/Contoso/Doc1.md/v1.0.0
-    $TagPattern = "VV/$RelativeRootPath/v*"
+    # Gets the pattern of tags with wildcard
+    $TagPattern = Get-GitBlobTagName -RelativeRootPath $RelativeRootPath -Pattern
 
     # Get tags with version data split by semicolon, sorted by version in descending order
     $Tags = Invoke-GitCommand 'tag', '--list', '--format=%(refname:short);%(contents)', '--sort=-version:refname', $TagPattern |
@@ -23,9 +24,13 @@ function Get-GitBlobTags {
             $JsonData = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Base64Data))
             $Metadata = $JsonData | ConvertFrom-Json
 
+            # Get the hash of the blob that the tag points to / contains
+            $Hash = (Invoke-GitCommand 'rev-list', '--objects', $Tag | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and $_ -notmatch $Tag }).Trim()
+
             [pscustomobject]@{
                 'File' = $RelativeRootPath
                 'Tag' = $Tag
+                'Hash' = $Hash
                 'Version' = $TagVersion
                 'Metadata' = $Metadata
             }

--- a/source/Private/Get-GitBlobTagName.ps1
+++ b/source/Private/Get-GitBlobTagName.ps1
@@ -1,0 +1,23 @@
+function Get-GitBlobTagName {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, ParameterSetName = 'Path')]
+        [Parameter(Mandatory, ParameterSetName = 'Pattern')]
+        [ValidateScript({ Test-Path $_ -IsValid }, ErrorMessage = 'Must be a valid path format, but does not need to exist (anymore).')]
+        [string]$RelativeRootPath,
+
+        [Parameter(Mandatory, ParameterSetName = 'Path')]
+        [version]$Version,
+        
+        [Parameter(Mandatory, ParameterSetName = 'Pattern')]
+        [switch]$Pattern
+    )
+
+    if ($Pattern) {
+        $OutputString = "@VV/$RelativeRootPath/v*"
+    } else {
+        $OutputString = "@VV/$RelativeRootPath/v$Version"
+    }
+
+    Write-Output $OutputString
+}

--- a/source/Private/Get-RelativeRootFilePath.ps1
+++ b/source/Private/Get-RelativeRootFilePath.ps1
@@ -1,0 +1,17 @@
+function Get-RelativeRootFilePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateScript({ Test-Path $_ -IsValid }, ErrorMessage = 'Must be a valid path format, but does not need to exist (anymore).')]
+        [string]$Path
+    )
+
+    Push-Location (Get-GitRepoRoot)
+
+    # Trim slashes from relative path
+    $RelativePath = (Resolve-Path $Path -Relative).TrimStart('.\').TrimStart('./')
+
+    Pop-Location
+
+    Write-Output $RelativePath
+}

--- a/source/Private/Test-GitBlobTag.ps1
+++ b/source/Private/Test-GitBlobTag.ps1
@@ -1,0 +1,14 @@
+function Test-GitBlobTag {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Tag
+    )
+    
+    try {
+        $null = Invoke-GitCommand 'tag', '--list', $Tag
+    } catch {}
+
+    # Returns true if the tag exists
+    $LASTEXITCODE -eq 0
+}

--- a/source/Public/Get-VVVersion.ps1
+++ b/source/Public/Get-VVVersion.ps1
@@ -1,10 +1,39 @@
 function Get-VVVersion {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ParameterSetName = 'Default')]
         [ValidateScript({ Test-Path $_ -PathType Leaf }, ErrorMessage = 'Path must exist and be a file.')]
-        [string]$Path
+        [string]$Path,
+
+        [Parameter(Mandatory, ParameterSetName = 'Checkout', HelpMessage = 'Checkout the version as a file using git blob tags.')]
+        [switch]$Checkout,
+
+        [Parameter(Mandatory, ParameterSetName = 'Checkout')]
+        [version]$Version
     )
+
+    if ($Checkout) {
+        # Ensure the path and version are specified for checkout
+        if (-not $Path -or -not $Version) {
+            Write-Error "Both -Path and -Version parameters must be specified when using -Checkout."
+            return
+        }
+
+        # Checkout logic
+        $RelativePath = (Resolve-Path $Path -Relative).TrimStart('.\').TrimStart('./')
+        $TagName = "VV/$RelativePath/v$Version"
+        $TagExists = Invoke-GitCommand 'tag', '--list', $TagName
+
+        if (-not $TagExists) {
+            Write-Error "The specified version tag '$TagName' does not exist."
+            return
+        }
+
+        $BlobHash = Invoke-GitCommand 'rev-parse', $TagName
+        Invoke-GitCommand 'checkout', $BlobHash, '--', $Path
+        Write-Verbose "Checked out version '$Version' of '$Path' successfully."
+        return
+    }
 
     # Get all tags based on file names
     $FileNames = Get-GitFileHistoryNames -Path $Path

--- a/source/Public/Get-VVVersion.ps1
+++ b/source/Public/Get-VVVersion.ps1
@@ -1,48 +1,28 @@
 function Get-VVVersion {
-    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    [CmdletBinding(DefaultParameterSetName = 'Path')]
     param (
-        [Parameter(Mandatory, ParameterSetName = 'Default')]
+        [Parameter(Mandatory, ParameterSetName = 'Path')]
+        [Parameter(Mandatory, ParameterSetName = 'Checkout')]
         [ValidateScript({ Test-Path $_ -PathType Leaf }, ErrorMessage = 'Path must exist and be a file.')]
         [string]$Path,
-
-        [Parameter(Mandatory, ParameterSetName = 'Checkout', HelpMessage = 'Checkout the version as a file using git blob tags.')]
-        [switch]$Checkout,
+        
+        [Parameter(ParameterSetName = 'Path')]
+        [Parameter(Mandatory, ParameterSetName = 'Checkout')]
+        [ValidateNotNullOrEmpty()]
+        [version]$Version,
 
         [Parameter(Mandatory, ParameterSetName = 'Checkout')]
-        [version]$Version
+        [switch]$Checkout,
+
+        [Parameter(ParameterSetName = 'Checkout')]
+        [switch]$Force
     )
-
-    if ($Checkout) {
-        # Ensure the path and version are specified for checkout
-        if (-not $Path -or -not $Version) {
-            Write-Error "Both -Path and -Version parameters must be specified when using -Checkout."
-            return
-        }
-
-        # Checkout logic
-        $RelativePath = (Resolve-Path $Path -Relative).TrimStart('.\').TrimStart('./')
-        $TagName = "VV/$RelativePath/v$Version"
-        $TagExists = Invoke-GitCommand 'tag', '--list', $TagName
-
-        if (-not $TagExists) {
-            Write-Error "The specified version tag '$TagName' does not exist."
-            return
-        }
-
-        $BlobHash = Invoke-GitCommand 'rev-parse', $TagName
-        Invoke-GitCommand 'checkout', $BlobHash, '--', $Path
-        Write-Verbose "Checked out version '$Version' of '$Path' successfully."
-        return
-    }
 
     # Get all tags based on file names
     $FileNames = Get-GitFileHistoryNames -Path $Path
-    Write-Verbose @"
-Found the following file path(s) of the file through the commit history:
-- $($FileNames -join "`n- ")
-"@
+    
     $Tags = $FileNames | ForEach-Object {
-        Get-GitBlobTags -RelativeRootPath $_
+        Get-GitBlobTag -RelativeRootPath $_
     }
 
     if ($Tags.Count -eq 0) {
@@ -50,5 +30,34 @@ Found the following file path(s) of the file through the commit history:
         return
     }
 
+    # If a version is specified, return the tag with the version
+    if ($null -ne $Version -and -not $Checkout.IsPresent) {
+        $TagInfo = $Tags | Where-Object Version -eq $Version
+        if ($null -eq $TagInfo) {
+            throw "The specified version '$Version' of file '$Path' does not exist."
+        }
+        return $TagInfo
+    }
+
+    # If checkout is specified, checkout the version
+    if ($Checkout.IsPresent) {
+        if (Test-GitFileIsModified -Path $Path -and -not $Force.IsPresent) {
+            throw "The file '$Path' has been modified. Please commit or discard the changes before checking out a version, or override the file using the -Force parameter."
+        }
+
+        $RelativePath = Get-RelativeRootFilePath -Path $Path
+        $TagInfo = $Tags | Where-Object Version -eq $Version
+        
+        if ($null -eq $TagInfo) {
+            throw "The specified version '$Version' of file '$Path' does not exist."
+        }
+
+        $FileContent = Invoke-GitCommand 'show', $TagInfo.Hash
+        Set-Content -Path $Path -Value $FileContent -Force:$Force.IsPresent
+        Write-Verbose "Checked out version '$Version' of '$Path' successfully."
+        return
+    }
+
+    # Return all tags if no version is specified
     Write-Output $Tags
 }

--- a/source/Public/Get-VVVersion.ps1
+++ b/source/Public/Get-VVVersion.ps1
@@ -41,7 +41,7 @@ function Get-VVVersion {
 
     # If checkout is specified, checkout the version
     if ($Checkout.IsPresent) {
-        if (Test-GitFileIsModified -Path $Path -and -not $Force.IsPresent) {
+        if ((Test-GitFileIsModified -Path $Path) -and -not $Force.IsPresent) {
             throw "The file '$Path' has been modified. Please commit or discard the changes before checking out a version, or override the file using the -Force parameter."
         }
 

--- a/source/Public/Remove-VVVersion.ps1
+++ b/source/Public/Remove-VVVersion.ps1
@@ -18,7 +18,7 @@ function Remove-VVVersion {
         $FileNames = Get-GitFileHistoryNames -Path $Path
 
         $Tags = $FileNames | ForEach-Object {
-            Get-GitBlobTags -RelativeRootPath $_
+            Get-GitBlobTag -RelativeRootPath $_
         }
 
         $Tag = $Tags | Where-Object { $_.Version -eq $Version } | Select-Object -ExpandProperty Tag

--- a/source/Public/Set-VVVersion.ps1
+++ b/source/Public/Set-VVVersion.ps1
@@ -23,7 +23,7 @@ function Set-VVVersion {
     }
 
     # Set extra metadata for the tag
-    if ($Metadata.ContainsKey('Commit')) { Write-Warning "The 'Commit' key was provided, and will not be overwritten with current commit." }
+    if ($Metadata.ContainsKey('Commit')) { Write-Warning "The 'Commit' key was provided, and will be used instead of current commit." }
     $Metadata['Commit'] ??= Get-GitCurrentCommit
     
     # Assemble metadata, convert to JSON and then to Base64

--- a/tests/Integration.Tests.ps1
+++ b/tests/Integration.Tests.ps1
@@ -72,17 +72,25 @@ Describe "Integration Tests for Get- and Set-VVVersion" {
 
     It "Checks out a version as a file using the -Checkout parameter" {
         # Create a new version with specific content
-        $VersionContent = "This is a specific version content."
-        Set-Content -Path $FilePath -Value $VersionContent
+        $Version2Content = "This is a specific version 2 content."
+        Set-Content -Path $FilePath -Value $Version2Content
         git add .
-        git commit -m "Committing specific version content"
-        Set-VVVersion -Path $FilePath -Version "2.0.0" -Metadata @{ Description = "Specific version for checkout test" }
+        git commit -m "Committing version 2"
+        Set-VVVersion -Path $FilePath -Version "2.0.0" -Metadata @{ Description = "Specific version 2 for checkout test" }
+        $Version3Content = "This is a specific version 3 content."
+        Set-Content -Path $FilePath -Value $Version3Content
+        git add .
+        git commit -m "Committing version 3"
+        Set-VVVersion -Path $FilePath -Version "3.0.0" -Metadata @{ Description = "Specific version 3 for checkout test" }
+
+
+        # Verify the file content matches the specific version content before checkout
+        Get-Content -Path $FilePath | Should -Be $Version3Content
 
         # Checkout the version using the -Checkout parameter
         Get-VVVersion -Path $FilePath -Checkout -Version "2.0.0"
 
-        # Verify the file content matches the specific version content
-        $FileContent = Get-Content -Path $FilePath
-        $FileContent | Should -Be $VersionContent
+        # Verify the file content matches the specific version content after checkout
+        Get-Content -Path $FilePath | Should -Be $Version2Content
     }
 }

--- a/tests/Integration.Tests.ps1
+++ b/tests/Integration.Tests.ps1
@@ -69,4 +69,20 @@ Describe "Integration Tests for Get- and Set-VVVersion" {
         $Versions = Get-VVVersion -Path $FilePath
         $Versions.Count | Should -Be 2
     }
+
+    It "Checks out a version as a file using the -Checkout parameter" {
+        # Create a new version with specific content
+        $VersionContent = "This is a specific version content."
+        Set-Content -Path $FilePath -Value $VersionContent
+        git add .
+        git commit -m "Committing specific version content"
+        Set-VVVersion -Path $FilePath -Version "2.0.0" -Metadata @{ Description = "Specific version for checkout test" }
+
+        # Checkout the version using the -Checkout parameter
+        Get-VVVersion -Path $FilePath -Checkout -Version "2.0.0"
+
+        # Verify the file content matches the specific version content
+        $FileContent = Get-Content -Path $FilePath
+        $FileContent | Should -Be $VersionContent
+    }
 }

--- a/tests/Integration.Tests.ps1
+++ b/tests/Integration.Tests.ps1
@@ -84,8 +84,7 @@ Describe "Integration Tests for Get- and Set-VVVersion" {
         git add .
         git commit -m "Committing version 3"
         Set-VVVersion -Path $FilePath -Version "3.0.0" -Metadata @{ Description = "Specific version 3 for checkout test" }
-
-
+        
         # Verify the file content matches the specific version content before checkout
         Get-Content -Path $FilePath | Should -Be $Version3Content
 

--- a/tests/Integration.Tests.ps1
+++ b/tests/Integration.Tests.ps1
@@ -70,14 +70,16 @@ Describe "Integration Tests for Get- and Set-VVVersion" {
         $Versions.Count | Should -Be 2
     }
 
-    It "Checks out a version as a file using the -Checkout parameter" {
+    It "Checks out a file version with a commit using the -Checkout parameter" {
         # Create a new version with specific content
         $Version2Content = "This is a specific version 2 content."
+        $Version3Content = "This is a specific version 3 content."
+
         Set-Content -Path $FilePath -Value $Version2Content
         git add .
         git commit -m "Committing version 2"
         Set-VVVersion -Path $FilePath -Version "2.0.0" -Metadata @{ Description = "Specific version 2 for checkout test" }
-        $Version3Content = "This is a specific version 3 content."
+        
         Set-Content -Path $FilePath -Value $Version3Content
         git add .
         git commit -m "Committing version 3"


### PR DESCRIPTION
Adds support for a new `-Checkout` parameter in the `Get-VVVersion` cmdlet, enabling users to checkout a version of a file using git blob tags. This update includes changes to the function definition, documentation, and integration tests.

- **Functionality Update**: Modifies `Get-VVVersion` in `source/Public/Get-VVVersion.ps1` to include a `-Checkout` switch parameter, allowing for the checkout of specific versions of a file. Implements logic to ensure the `-Path` and `-Version` parameters are specified when using `-Checkout`.
- **Documentation Enhancement**: Updates `docs/help/Get-VVVersion.md` to describe the new `-Checkout` parameter and provides usage examples, ensuring users understand how to use the new functionality.
- **Testing Expansion**: Adds a new integration test in `tests/Integration.Tests.ps1` to verify the checkout functionality works as expected, ensuring reliability of the new feature.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PalmEmanuel/VeilVer?shareId=0a79a819-1089-4dc4-a105-d3d1d6257c67).